### PR TITLE
Security Patches :D

### DIFF
--- a/contrib/optimizations/inflate.c
+++ b/contrib/optimizations/inflate.c
@@ -771,8 +771,9 @@ int flush;
                 if (copy > have) copy = have;
                 if (copy) {
                     if (state->head != Z_NULL &&
-                        state->head->extra != Z_NULL) {
-                        len = state->head->extra_len - state->length;
+                        state->head->extra != Z_NULL &&
+                        (len = state->head->extra_len - state->length) <
+                            state->head->extra_max) {
                         zmemcpy(state->head->extra + len, next,
                                 len + copy > state->head->extra_max ?
                                 state->head->extra_max - len : copy);

--- a/inflate.c
+++ b/inflate.c
@@ -760,8 +760,9 @@ int flush;
                 if (copy > have) copy = have;
                 if (copy) {
                     if (state->head != Z_NULL &&
-                        state->head->extra != Z_NULL) {
-                        len = state->head->extra_len - state->length;
+                        state->head->extra != Z_NULL &&
+                        (len = state->head->extra_len - state->length) <
+                            state->head->extra_max) {
                         zmemcpy(state->head->extra + len, next,
                                 len + copy > state->head->extra_max ?
                                 state->head->extra_max - len : copy);


### PR DESCRIPTION
If the extra field was larger than the space the user provided with inflateGetHeader(), and if multiple calls of inflate() delivered the extra header data, then there could be a buffer overflow of the provided space. This commit assures that provided space is not exceeded.

Bug: http://b/242299736
Test: TreeHugger

Change-Id: I4eabb3e135c1568e06b2b9740651a3ae11b21140 (cherry picked from commit 1c4806afd7ae034aa9f86df35d4341a0b175a90a) Merged-In: I4eabb3e135c1568e06b2b9740651a3ae11b21140